### PR TITLE
Remove react and react-dom from the package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "d3-scale": "^3.2.3",
     "d3-scale-chromatic": "^2.0.0",
     "d3-shape": "^2.0.0",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "styled-components": "^4.3.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Removed react and react-dom from the package.json dependencies. Should help with newer version of React.

Closes #4 