### PR TITLE
Fix issue #4 Invalid hook call on react

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "d3-scale": "^3.2.3",
     "d3-scale-chromatic": "^2.0.0",
     "d3-shape": "^2.0.0",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "styled-components": "^4.3.2"
   },
   "peerDependencies": {
@@ -84,6 +82,8 @@
     "@storybook/react": "^6.1.9",
     "@storybook/theming": "latest",
     "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
     "tabletop": "^1.5.2"
   }


### PR DESCRIPTION
I believe removing react and react-dom from devs to dev devs should resolve the issue with the error:

Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons: 1. You might have mismatching versions of React and the renderer (such as React DOM) 2. You might be breaking the Rules of Hooks 3. You might have more than one copy of React in the same app See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.